### PR TITLE
add documentation on requirements and GCM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,20 @@ push_notifications
 
 The Push Notifications module for DrupalGap helps users to send push messages from their Drupal website to devices.
 
+Requirements
+============
+
+PushPlugin for Phonegap: https://github.com/phonegap-build/PushPlugin
+
+You can install the plugin from the command line like this:
+cordova plugin add https://github.com/phonegap-build/PushPlugin.git
+
+Configuration
+=============
+
+If using Android, you will need to add your GCM Sender ID to the second line of push_notifications.js.
+
+Tutorial
+========
+
 For a walk through on how to set up push_notifications for your DrupalGap application please refer to http://vjsamuel.wordpress.com/2015/01/12/push-notifications-on-drupalgap/


### PR DESCRIPTION
There appears to be an undocumented dependency on PushPlugin for phonegap.  Also, different from general Drupal 7 module practices, the GCM Sender ID actually has to be set in the contrib module .js file, so I think there should be an explicit note about this.
